### PR TITLE
Greater then branching logic does not work.

### DIFF
--- a/lib/surveyor/redcap_parser.rb
+++ b/lib/surveyor/redcap_parser.rb
@@ -69,7 +69,7 @@ module Surveyor
             Surveyor::RedcapParser.rake_trace "...found "
             dc.question = context[:question_references][dc.question_reference]
             dc.answer = dc.question.answers.first
-          elsif answer = context[:answer_references][dc.question_reference][dc.answer_reference]
+          elsif context[:answer_references] && answer = context[:answer_references][dc.question_reference][dc.answer_reference]
             Surveyor::RedcapParser.rake_trace "...found "
             dc.answer = answer
             dc.question = context[:question_references][dc.question_reference]
@@ -211,7 +211,7 @@ module SurveyorRedcapParserAnswerMethods
     case r[:field_type]
     when "text"
       self.attributes = {
-        :response_class => "string",
+        :response_class => r[:text_validation_type],
         :text => "Text",
         :display_order => context[:question].answers.size }
       context[:question].answers << context[:answer] = self


### PR DESCRIPTION
">" and "<"  in a branching condition check on a fill in textbox does not trigger Ajax call to show hidden question.  This depedency condition is saved and an AJAX call is made, but javascript is not updated with the show values.

Examples:
- SecondHandSmoke_DataDictionary_2014-02-24_2.csv with  [spouse_smoke_yrs] > 0.  spouse_smoke_yrs is the referrant answer and is a  textbox;   
- redcap_siblings.csv survey with  [sibs]>0
