### PR TITLE
Problem with parser when dependency condition on a text field

### DIFF
--- a/lib/surveyor/parser.rb
+++ b/lib/surveyor/parser.rb
@@ -68,6 +68,14 @@ module Surveyor
     # This method_missing does all the heavy lifting for the DSL
     def method_missing(missing_method, *args, &block)
       method_name, reference_identifier = missing_method.to_s.split("_", 2)
+
+      # Quick fix to allow validations and dependencies on a single question.
+      if method_name == 'validation'
+        context[:last] = 'validation'
+      elsif method_name == 'dependency'
+        context[:last] = 'dependency'
+      end
+
       type = full(method_name)
       Surveyor::Parser.raise_error( "\"#{type}\" is not a surveyor method." )if !%w(survey survey_translation survey_section question_group question dependency dependency_condition answer validation validation_condition).include?(type)
 
@@ -113,7 +121,7 @@ module Surveyor
       when /^q$|^label$|^image$/; "question"
       when /^a$/; "answer"
       when /^d$/; "dependency"
-      when /^c(ondition)?$/; context[:validation] ? "validation_condition" : "dependency_condition"
+      when /^c(ondition)?$/; context[:last] == 'validation' ? "validation_condition" : "dependency_condition"
       when /^v$/; "validation"
       when /^dc(ondition)?$/; "dependency_condition"
       when /^vc(ondition)?$/; "validation_condition"


### PR DESCRIPTION
When you build redcap_siblings.csv, unparse it to a DSL, then build from DSL, this build fails.  This appears to be the inverse of the problem solved by #3.  I think the regular parser needs to be updated like the redcap parser was in #3.

```
To build from csv:
$ bundle exec rake surveyor:redcap FILE=surveys/redcap-siblings.csv

To unparse into a DSL document (choose survey id at prompt):
$bundle exec rake surveyor:unparse

To build survey from DSL file
$  bundle exec rake surveyor FILE=surveys/redcap-siblings_2014-03-12.rb
--- Parsing /Users/toddparsnick/Repos/HeHStudy/HeH/surveys/redcap-siblings_2014-03-12.rb ---
rake aborted!
can't convert String into Hash
/Users/toddparsnick/.rvm/gems/ruby-1.9.3-p327@HeH/bundler/gems/surveyor-2b988ebdf7e6/lib/surveyor/parser.rb:65:in `instance_eval'
/Users/toddparsnick/.rvm/gems/ruby-1.9.3-p327@HeH/bundler/gems/surveyor-2b988ebdf7e6/lib/surveyor/parser.rb:425:in `parse_and_build'
/Users/toddparsnick/.rvm/gems/ruby-1.9.3-p327@HeH/bundler/gems/surveyor-2b988ebdf7e6/lib/surveyor/parser.rb:82:in `method_missing'
(eval):18:in `block (2 levels) in parse'
```

appears to be issue with the following line from DSL.  q_sibs is a text field.

```
   condition_A :q_sibs, ">", {:integer_value=>0, :answer_reference=>""}
```
