### PR TITLE
Fixed migration files with api in classname

### DIFF
--- a/lib/generators/surveyor/templates/db/migrate/add_api_id_to_question_groups.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_api_id_to_question_groups.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddApiIdToQuestionGroups < ActiveRecord::Migration
+class AddAPIIdToQuestionGroups < ActiveRecord::Migration
   def self.up
     add_column :question_groups, :api_id, :string
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_api_ids.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_api_ids.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddApiIds < ActiveRecord::Migration
+class AddAPIIds < ActiveRecord::Migration
   def self.up
     add_column :surveys, :api_id, :string
     add_column :questions, :api_id, :string

--- a/lib/generators/surveyor/templates/db/migrate/add_api_ids_to_response_sets_and_responses.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_api_ids_to_response_sets_and_responses.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddApiIdsToResponseSetsAndResponses < ActiveRecord::Migration
+class AddAPIIdsToResponseSetsAndResponses < ActiveRecord::Migration
   def self.up
     add_column :response_sets, :api_id, :string
     add_column :responses, :api_id, :string

--- a/lib/generators/surveyor/templates/db/migrate/api_ids_must_be_unique.rb
+++ b/lib/generators/surveyor/templates/db/migrate/api_ids_must_be_unique.rb
@@ -1,4 +1,4 @@
-class ApiIdsMustBeUnique < ActiveRecord::Migration
+class APIIdsMustBeUnique < ActiveRecord::Migration
   API_ID_TABLES = %w(surveys questions question_groups answers responses response_sets)
 
   class << self

--- a/lib/generators/surveyor/templates/db/migrate/update_blank_api_ids_on_question_group.rb
+++ b/lib/generators/surveyor/templates/db/migrate/update_blank_api_ids_on_question_group.rb
@@ -6,7 +6,7 @@ class Answer < ActiveRecord::Base; end
 class Response < ActiveRecord::Base; end
 class ResponseSet < ActiveRecord::Base; end
 
-class UpdateBlankApiIdsOnQuestionGroup < ActiveRecord::Migration
+class UpdateBlankAPIIdsOnQuestionGroup < ActiveRecord::Migration
   def self.up
     check = [Survey, Question, QuestionGroup, Answer, Response, ResponseSet]
     check.each do |clazz|


### PR DESCRIPTION
When setting up the project, you get an error when running migrations created by the install.

rails generate surveyor:install
bundle exec rake db:migrate  
```
rake aborted!
uninitialized constant AddAPIIds
/home/heh/bundler/ruby/2.1.0/gems/activesupport-4.2.3/lib/active_support/inflector/methods.rb:261:in `const_get'
/home/heh/bundler/ruby/2.1.0/gems/activesupport-4.2.3/lib/active_support/inflector/methods.rb:261:in `block in constantize'
```
These fixes make API uppercase in the Class name so that the migrations work