### PR TITLE
Fix include blank error when an attribute is required on rails 5

### DIFF
--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -14,7 +14,7 @@
         = ff.input :question_id, :as => :quiet
         = ff.input :response_group, :as => :quiet, :input_html => {:value => rg} if g && g.display_type == "repeater"
         = ff.input :api_id, :as => :quiet
-        = ff.input :answer_id, :as => :select, :collection => q.answers.map{|a| [a.text, a.id]}, :include_blank => (renderer != :slider), :label => q.text, :input_html => { :disabled => disabled, :required => q.mandatory? }
+        = ff.input :answer_id, :as => :select, :collection => q.answers.map{|a| [a.text, a.id]}, :include_blank => (renderer != :slider) ||  '', :label => q.text, :input_html => { :disabled => disabled, :required => q.mandatory? }
     - else # :default, :inline, :inline_default
       - if q.pick == "one"
         - r = response_for(@response_set, q, nil, rg)


### PR DESCRIPTION
In rails 5 include_blank option is set true by default, but if the attribute is required the field must not be set with false value or we'll get an error