### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -25,10 +25,9 @@ module Surveyor
 
       module ClassMethods
         def has_blank_value?(hash)
-          hash = hash.transform_values
           return true if hash["answer_id"].blank?
           return false if (q = Question.find_by_id(hash["question_id"])) and q.pick == "one"
-          hash.any?{|k,v| v.is_a?(Array) ? v.all?{|x| x.to_s.blank?} : v.to_s.blank?}
+          hash.to_h.any?{|k,v| v.is_a?(Array) ? v.all?{|x| x.to_s.blank?} : v.to_s.blank?}
         end
       end
 

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -25,6 +25,7 @@ module Surveyor
 
       module ClassMethods
         def has_blank_value?(hash)
+          hash = hash.transform_values
           return true if hash["answer_id"].blank?
           return false if (q = Question.find_by_id(hash["question_id"])) and q.pick == "one"
           hash.any?{|k,v| v.is_a?(Array) ? v.all?{|x| x.to_s.blank?} : v.to_s.blank?}


### PR DESCRIPTION
This changes fixes a deprecation warning by rails 5.X

```
DEPRECATION WARNING: Method any? is deprecated and will be removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from hash. Using this deprecated behavior exposes potential security problems. If you continue to use this method you may be creating a security vulnerability in your app that can be exploited. Instead, consider using one of these documented methods which are not deprecated: http://api.rubyonrails.org/v5.0.0.1/classes/ActionController/Parameters.html (called from block in has_aspirin? at lib/surveyor/models/response_set_methods.rb:30)
```