### PR TITLE
77 Use display type instead of reference identifier for email answer type

### DIFF
--- a/app/views/surveyor/export.json.rabl
+++ b/app/views/surveyor/export.json.rabl
@@ -21,8 +21,8 @@ child :sections => :sections do
     node(:type,                     :if => lambda { |q| q.display_type != "default" }){ |q| q.display_type }
     #needed for the mobile app to parse the question based on its answer response_class
     #Currently we are not supporting multiple answers when it's not a pick question that's why we are grabbing the first answer type
-    node(:answer_type, :if => lambda { |q| q.is_a?(Question) && q.pick == "none" && q.answers.present? && q.reference_identifier != "email"}){ |q| q.answers.first.response_class }
-    node(:answer_type, :if => lambda {|q| q.is_a?(Question) && q.reference_identifier == "email"}) {"email"}
+    node(:answer_type, :if => lambda { |q| q.is_a?(Question) && q.pick == "none" && q.answers.present? && q.display_type != "email"}){ |q| q.answers.first.response_class }
+    node(:answer_type, :if => lambda {|q| q.is_a?(Question) && q.display_type == "email"}) {"email"}
 
     # only questions
     node(:pick,                     :if => lambda { |q| q.is_a?(Question) && q.pick != "none" }){ |q| q.pick }


### PR DESCRIPTION
Updated app/views/surveyor/export.json.rabl to use display type instead of reference identifier for email answer type.