### PR TITLE
patch surveyor jquery bc of its erroneous type conversion issue

### DIFF
--- a/lib/assets/javascripts/surveyor/jquery.validate.js
+++ b/lib/assets/javascripts/surveyor/jquery.validate.js
@@ -1118,17 +1118,17 @@ $.extend($.validator, {
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/min
 		min: function( value, element, param ) {
-			return this.optional(element) || value >= param;
+			return this.optional(element) || Number(value) >= Number(param);
 		},
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/max
 		max: function( value, element, param ) {
-			return this.optional(element) || value <= param;
+			return this.optional(element) || Number(value) <= Number(param);
 		},
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/range
 		range: function( value, element, param ) {
-			return this.optional(element) || ( value >= param[0] && value <= param[1] );
+			return this.optional(element) || ( Number(value) >= Number(param[0]) && Number(value) <= Number(param[1]) );
 		},
 
 		// http://docs.jquery.com/Plugins/Validation/Methods/equalTo


### PR DESCRIPTION
Abel brought up that the float validator was buggy, so I looked into it and patched the original validator to be accurate. The problem came from javascript's type conversion when comparing string numbers like "2" >= "20.00" and "3" >= "20.00" being true because "2" and "3" is greater than the "2" in "20.00".

Updated the surveyor to avoid javascript's type conversion. 

PAT:
https://www.screencast.com/t/lzxW7Nf7at