### PR TITLE
Email type comes from display type, not reference identifier

### DIFF
--- a/app/views/surveyor/export.json.rabl
+++ b/app/views/surveyor/export.json.rabl
@@ -23,8 +23,8 @@ child :sections => :sections do
     node(:type,                     :if => lambda { |q| q.display_type != "default" }){ |q| q.display_type }
     #needed for the mobile app to parse the question based on its answer response_class
     #Currently we are not supporting multiple answers when it's not a pick question that's why we are grabbing the first answer type
-    node(:answer_type, :if => lambda { |q| q.is_a?(Question) && q.pick == "none" && q.answers.present? && q.reference_identifier != "email"}){ |q| q.answers.first.response_class }
-    node(:answer_type, :if => lambda {|q| q.is_a?(Question) && q.reference_identifier == "email"}) {"email"}
+    node(:answer_type, :if => lambda { |q| q.is_a?(Question) && q.pick == "none" && q.answers.present? && q.display_type != "email"}){ |q| q.answers.first.response_class }
+    node(:answer_type, :if => lambda {|q| q.is_a?(Question) && q.display_type == "email"}) {"email"}
 
     # only questions
     node(:pick,                     :if => lambda { |q| q.is_a?(Question) && q.pick != "none" }){ |q| q.pick }


### PR DESCRIPTION
Using reference identifier to determine the type means we cant have more than one question of email type in a survey, this is wrong.

Before change
![image](https://user-images.githubusercontent.com/5491353/83568743-5e49af80-a4d8-11ea-96c1-40ba8bd96a58.png)


After change
![image](https://user-images.githubusercontent.com/5491353/83568769-686bae00-a4d8-11ea-93dc-d17940b4cd8a.png)
