### PR TITLE
Question type should not change if display type is email

### DIFF
--- a/app/views/surveyor/export.json.rabl
+++ b/app/views/surveyor/export.json.rabl
@@ -20,7 +20,7 @@ child :sections => :sections do
     node(:help_text,                :if => lambda { |q| !q.help_text.blank? }){ |q| q.help_text }
     node(:reference_identifier,     :if => lambda { |q| !q.reference_identifier.blank? }){ |q| q.reference_identifier }
     node(:data_export_identifier,   :if => lambda { |q| !q.data_export_identifier.blank? }){ |q| q.data_export_identifier }
-    node(:type,                     :if => lambda { |q| q.display_type != "default" }){ |q| q.display_type }
+    node(:type,                     :if => lambda { |q| q.display_type != "default" && q.display_type != "email" }){ |q| q.display_type }
     #needed for the mobile app to parse the question based on its answer response_class
     #Currently we are not supporting multiple answers when it's not a pick question that's why we are grabbing the first answer type
     node(:answer_type, :if => lambda { |q| q.is_a?(Question) && q.pick == "none" && q.answers.present? && q.display_type != "email"}){ |q| q.answers.first.response_class }


### PR DESCRIPTION
This change is needed to avoid updating question type when display type is email. Otherwise the app wont handle the question. From ios repo:
![image](https://user-images.githubusercontent.com/5491353/84204107-792f9d00-aa5f-11ea-97de-5f029a13c0ff.png)
