### PR TITLE
Pick any questions only mandatory if is_mandatory is true

### DIFF
--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -12,8 +12,7 @@
     = ff.input :answer_id, :as => :surveyor_radio, :collection => [[a.text_for(nil, @render_context, I18n.locale), a.id]], :label => false, :input_html => {:class => a.css_class, :disabled => disabled}, :response_class => a.response_class, :required => q.mandatory?
   - when "any"
     - css_class = "#{a.css_class} surveyor_checkboxes_answer"
-    - if q.mandatory?
-      - css_class << " at_least_one"
+    - css_class << " at_least_one" if q.mandatory?
     = ff.input :answer_id, :as => :surveyor_check_boxes, :collection => [[a.text_for(nil, @render_context, I18n.locale), a.id]], :label => false, :input_html => {:class => css_class, :disabled => disabled}, :response_class => a.response_class
   - when "none"
     - if %w(date datetime time float integer string text).include? a.response_class

--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -11,7 +11,9 @@
   - when "one"
     = ff.input :answer_id, :as => :surveyor_radio, :collection => [[a.text_for(nil, @render_context, I18n.locale), a.id]], :label => false, :input_html => {:class => a.css_class, :disabled => disabled}, :response_class => a.response_class, :required => q.mandatory?
   - when "any"
-    - css_class = "#{a.css_class} surveyor_checkboxes_answer at_least_one"
+    - css_class = "#{a.css_class} surveyor_checkboxes_answer"
+    - if q.mandatory?
+      - css_class << " at_least_one"
     = ff.input :answer_id, :as => :surveyor_check_boxes, :collection => [[a.text_for(nil, @render_context, I18n.locale), a.id]], :label => false, :input_html => {:class => css_class, :disabled => disabled}, :response_class => a.response_class
   - when "none"
     - if %w(date datetime time float integer string text).include? a.response_class


### PR DESCRIPTION
Right now all pick any questions are given the class 'at_least_one' making the question mandatory even when `is_mandatory` is false.

Questions should only be mandatory when `is_mandatory` equals true